### PR TITLE
Feature/revamp

### DIFF
--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -116,7 +116,7 @@ export default function Home() {
 
           {/* Projects Section */}
           <section
-            className="section-spacing"
+            className="pt-8 md:pt-16 pb-10 md:pb-18"
             id="projects"
             data-aos="fade-up"
             data-aos-duration="1000"
@@ -204,7 +204,7 @@ export default function Home() {
 
           {/* Social & CTA Footer */}
           <section
-            className="section-spacing"
+            className="pb-8 md:pb-16"
             data-aos="fade-up"
             data-aos-duration="1200"
           >

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -11,10 +11,10 @@ function BlogPostCard({ post }: BlogPostCardProps) {
   // Format tanggal jika tersedia - memoized to prevent unnecessary date formatting
   const formattedDate = useMemo(() => {
     return post.created_at
-      ? new Date(post.created_at).toLocaleDateString('id-ID', {
-          day: 'numeric',
+      ? new Date(post.created_at).toLocaleDateString('en-US', {
+          year: 'numeric',
           month: 'long',
-          year: 'numeric'
+          day: 'numeric'
         })
       : null;
   }, [post.created_at]);

--- a/src/index.css
+++ b/src/index.css
@@ -252,7 +252,7 @@ pre.shiki code .line {
 
   /* Section Spacing */
   .section-spacing {
-    @apply py-16 md:py-24;
+    @apply py-8 md:py-16;
   }
 
   .section-spacing-lg {


### PR DESCRIPTION
style: Update blog list date format to match detail blog
Change blog list date format from Indonesian (id-ID) to English (en-US) to match the detail blog page format. Dates now display as "March 3, 2025" instead of localized Indonesian format for consistency.

style: Adjust section spacing and padding for better layout
Reduced vertical spacing in section-spacing utility class and updated custom spacing for Projects and Footer sections to improve overall page layout proportions.